### PR TITLE
Add section for pending talks

### DIFF
--- a/apps/admin/src/app/api/talks/route.ts
+++ b/apps/admin/src/app/api/talks/route.ts
@@ -5,6 +5,44 @@ import { TalkMetadata } from "@gdg/ui-theme";
 
 const TALKS_DIR = path.join(process.cwd(), "../../talks");
 
+export async function GET() {
+  try {
+    const talks: any[] = [];
+    const years = await fs.readdir(TALKS_DIR).catch(() => []);
+    
+    for (const year of years) {
+      if (!/^\d{4}$/.test(year)) continue;
+      const yearDir = path.join(TALKS_DIR, year);
+      const stat = await fs.stat(yearDir);
+      if (!stat.isDirectory()) continue;
+      
+      const folders = await fs.readdir(yearDir).catch(() => []);
+      for (const folder of folders) {
+        const talkDir = path.join(yearDir, folder);
+        const folderStat = await fs.stat(talkDir);
+        if (!folderStat.isDirectory()) continue;
+        
+        try {
+          const metaContent = await fs.readFile(path.join(talkDir, "meta.json"), "utf8");
+          const meta = JSON.parse(metaContent);
+          talks.push({
+            slug: folder,
+            year,
+            ...meta
+          });
+        } catch (e) {
+          // ignore missing or malformed meta.json
+        }
+      }
+    }
+    
+    talks.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+    return NextResponse.json(talks);
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}
+
 export async function POST(req: Request) {
   try {
     const formData = await req.formData();
@@ -21,6 +59,9 @@ export async function POST(req: Request) {
     const description = formData.get("description") as string;
     const eventLink = formData.get("eventLink") as string;
     
+    const originalSlug = formData.get("originalSlug") as string;
+    const originalYear = formData.get("originalYear") as string;
+
     const file = formData.get("file") as File;
 
     if (!title) {
@@ -49,6 +90,19 @@ export async function POST(req: Request) {
 
     const targetDir = path.join(TALKS_DIR, year, sanitizedTitle);
     
+    if (originalSlug && originalYear) {
+      const originalDir = path.join(TALKS_DIR, originalYear, originalSlug);
+      if (originalDir !== targetDir) {
+        try {
+          await fs.stat(originalDir);
+          await fs.mkdir(path.join(TALKS_DIR, year), { recursive: true });
+          await fs.rename(originalDir, targetDir);
+        } catch (e) {
+          // Do nothing if original dir doesn't exist
+        }
+      }
+    }
+
     // Create directory
     await fs.mkdir(targetDir, { recursive: true });
     

--- a/apps/admin/src/app/api/talks/route.ts
+++ b/apps/admin/src/app/api/talks/route.ts
@@ -21,7 +21,7 @@ export async function POST(req: Request) {
     
     const file = formData.get("file") as File;
 
-    if (!title || !file) {
+    if (!title) {
       return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
     }
 
@@ -57,10 +57,12 @@ export async function POST(req: Request) {
     );
 
     // Save PDF
-    const arrayBuffer = await file.arrayBuffer();
-    const buffer = Buffer.from(arrayBuffer);
-    const pdfPath = path.join(targetDir, file.name);
-    await fs.writeFile(pdfPath, buffer);
+    if (file) {
+      const arrayBuffer = await file.arrayBuffer();
+      const buffer = Buffer.from(arrayBuffer);
+      const pdfPath = path.join(targetDir, file.name);
+      await fs.writeFile(pdfPath, buffer);
+    }
 
     return NextResponse.json({ success: true, folder: sanitizedTitle });
   } catch (err: any) {

--- a/apps/admin/src/app/api/talks/route.ts
+++ b/apps/admin/src/app/api/talks/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import fs from "fs/promises";
 import path from "path";
+import { TalkMetadata } from "@gdg/ui-theme";
 
 const TALKS_DIR = path.join(process.cwd(), "../../talks");
 
@@ -27,7 +28,7 @@ export async function POST(req: Request) {
 
     const tags = tagsRaw.split(",").map(t => t.trim()).filter(Boolean);
 
-    const meta = {
+    const meta: TalkMetadata = {
       title,
       speaker,
       category,

--- a/apps/admin/src/app/api/talks/route.ts
+++ b/apps/admin/src/app/api/talks/route.ts
@@ -19,6 +19,7 @@ export async function POST(req: Request) {
     const event = formData.get("event") as string;
     const date = formData.get("date") as string;
     const description = formData.get("description") as string;
+    const eventLink = formData.get("eventLink") as string;
     
     const file = formData.get("file") as File;
 
@@ -37,7 +38,8 @@ export async function POST(req: Request) {
       level,
       event,
       date,
-      description
+      description,
+      ...(eventLink && { eventLink })
     };
 
     // Sanitize title for folder name

--- a/apps/admin/src/app/api/talks/route.ts
+++ b/apps/admin/src/app/api/talks/route.ts
@@ -11,7 +11,6 @@ export async function POST(req: Request) {
     // Extract metadata
     const title = formData.get("title") as string;
     const speaker = formData.get("speaker") as string;
-    const year = formData.get("year") as string;
     const category = formData.get("category") as string;
     const tagsRaw = formData.get("tags") as string;
     const language = formData.get("language") as string;
@@ -22,7 +21,7 @@ export async function POST(req: Request) {
     
     const file = formData.get("file") as File;
 
-    if (!title || !year || !file) {
+    if (!title || !file) {
       return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
     }
 
@@ -31,7 +30,6 @@ export async function POST(req: Request) {
     const meta = {
       title,
       speaker,
-      year: parseInt(year, 10),
       category,
       tags,
       language,
@@ -43,7 +41,9 @@ export async function POST(req: Request) {
 
     // Sanitize title for folder name
     const sanitizedTitle = title.toLowerCase().replace(/[^a-z0-9]/g, "_").replace(/_+/g, "_");
-    
+
+    const year = new Date(date).getFullYear().toString();
+
     const targetDir = path.join(TALKS_DIR, year, sanitizedTitle);
     
     // Create directory

--- a/apps/admin/src/app/api/talks/route.ts
+++ b/apps/admin/src/app/api/talks/route.ts
@@ -23,11 +23,15 @@ export async function GET() {
         if (!folderStat.isDirectory()) continue;
         
         try {
+          const files = await fs.readdir(talkDir).catch(() => []);
+          const pdfFile = files.find(f => f.endsWith('.pdf')) || null;
+
           const metaContent = await fs.readFile(path.join(talkDir, "meta.json"), "utf8");
           const meta = JSON.parse(metaContent);
           talks.push({
             slug: folder,
             year,
+            pdfFile,
             ...meta
           });
         } catch (e) {
@@ -61,6 +65,7 @@ export async function POST(req: Request) {
     
     const originalSlug = formData.get("originalSlug") as string;
     const originalYear = formData.get("originalYear") as string;
+    const deletePdf = formData.get("deletePdf") === "true";
 
     const file = formData.get("file") as File;
 
@@ -112,6 +117,19 @@ export async function POST(req: Request) {
       JSON.stringify(meta, null, 2),
       "utf-8"
     );
+
+    // Delete existing PDF if requested or if we are uploading a new one
+    if (deletePdf || file) {
+      try {
+        const files = await fs.readdir(targetDir);
+        const pdf = files.find((f: string) => f.endsWith('.pdf'));
+        if (pdf) {
+          await fs.unlink(path.join(targetDir, pdf));
+        }
+      } catch (e) {
+        // Ignore errors
+      }
+    }
 
     // Save PDF
     if (file) {

--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -19,16 +19,14 @@ export default function AdminPage() {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!file) {
-      setError("Bitte wähle eine PDF-Datei aus.");
-      return;
-    }
 
     setIsSubmitting(true);
     setError("");
 
     const formData = new FormData(e.currentTarget);
-    formData.append("file", file);
+    if (file) {
+      formData.append("file", file);
+    }
 
     try {
       const res = await fetch("/api/talks", {
@@ -140,7 +138,7 @@ export default function AdminPage() {
         </div>
 
         <div className="space-y-2">
-          <label className="text-sm font-semibold">Präsentationsfolien (PDF) *</label>
+          <label className="text-sm font-semibold">Präsentationsfolien (PDF)</label>
           <div
             {...getRootProps()}
             className={`border-2 border-dashed rounded-xl p-8 text-center cursor-pointer transition-colors ${isDragActive ? 'border-[var(--color-gdg-blue)] bg-blue-50' : 'border-[var(--color-gdg-grey-300)] hover:bg-[var(--color-gdg-grey-50)]'

--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 import { UploadCloud, CheckCircle, Loader2 } from "lucide-react";
 import { useDropzone } from "react-dropzone";
@@ -12,7 +12,27 @@ export default function AdminPage() {
   const [file, setFile] = useState<File | null>(null);
   const [date, setDate] = useState("");
 
+  const [mode, setMode] = useState<'add' | 'edit'>('add');
+  const [talks, setTalks] = useState<any[]>([]);
+  const [selectedTalk, setSelectedTalk] = useState<any | null>(null);
+  const [editSuccessMsg, setEditSuccessMsg] = useState("");
+
   const isFuture = date ? new Date(date) > new Date() : false;
+
+  useEffect(() => {
+    if (mode === 'edit') {
+      fetch('/api/talks').then(r => r.json()).then(data => setTalks(data)).catch(console.error);
+    }
+  }, [mode]);
+
+  useEffect(() => {
+    if (mode === 'edit' && selectedTalk) {
+      setDate(selectedTalk.date || "");
+    } else if (mode === 'add') {
+      setDate("");
+      setSelectedTalk(null);
+    }
+  }, [mode, selectedTalk]);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: { "application/pdf": [".pdf"] },
@@ -31,6 +51,11 @@ export default function AdminPage() {
       formData.append("file", file);
     }
 
+    if (mode === 'edit' && selectedTalk) {
+      formData.append("originalSlug", selectedTalk.slug);
+      formData.append("originalYear", selectedTalk.year.toString());
+    }
+
     try {
       const res = await fetch("/api/talks", {
         method: "POST",
@@ -43,6 +68,12 @@ export default function AdminPage() {
       }
 
       setSuccess(true);
+      if (mode === 'edit') {
+        setEditSuccessMsg(`Talk "${formData.get("title")}" erfolgreich aktualisiert!`);
+        fetch('/api/talks').then(r => r.json()).then(data => setTalks(data)).catch();
+      } else {
+        setEditSuccessMsg("Der Vortrag wurde lokal gespeichert und ist nun im Talks-Ordner verfügbar.");
+      }
       (e.target as HTMLFormElement).reset();
       setFile(null);
       setDate("");
@@ -57,11 +88,16 @@ export default function AdminPage() {
     return (
       <div className="max-w-2xl mx-auto text-center py-20 bg-card rounded-xl border border-[var(--color-gdg-grey-200)] flex flex-col items-center">
         <CheckCircle className="w-16 h-16 text-[var(--color-gdg-green)] mb-6" />
-        <h2 className="text-3xl font-bold mb-4">Talk erfolgreich hinzugefügt!</h2>
-        <p className="text-muted mb-8 text-lg">Der Vortrag wurde lokal gespeichert und ist nun im Talks-Ordner verfügbar.</p>
+        <h2 className="text-3xl font-bold mb-4">
+          {mode === 'edit' ? "Talk erfolgreich bearbeitet!" : "Talk erfolgreich hinzugefügt!"}
+        </h2>
+        <p className="text-muted mb-8 text-lg">{editSuccessMsg}</p>
         <div className="flex gap-4">
-          <button onClick={() => setSuccess(false)} className="px-6 py-2 bg-[var(--color-gdg-blue)] text-white font-medium rounded-lg hover:bg-blue-600 transition-colors">
-            Weiteren Talk hinzufügen
+          <button onClick={() => {
+            setSuccess(false);
+            if (mode === 'edit') setSelectedTalk(null);
+          }} className="px-6 py-2 bg-[var(--color-gdg-blue)] text-white font-medium rounded-lg hover:bg-blue-600 transition-colors">
+            {mode === 'edit' ? "Weiteren Talk bearbeiten" : "Weiteren Talk hinzufügen"}
           </button>
         </div>
       </div>
@@ -70,12 +106,63 @@ export default function AdminPage() {
 
   return (
     <div className="max-w-3xl mx-auto">
-      <div className="mb-8">
-        <h1 className="text-3xl font-extrabold mb-2">Neuen Talk hinterlegen</h1>
-        <p className="text-muted text-lg">Fülle das Formular aus und lade die PDF hoch, um einen neuen Vortrag anzulegen.</p>
+      
+      <div className="relative flex bg-[#F1F3F4] rounded-2xl p-1.5 w-full max-w-xs mx-auto mb-10 overflow-hidden shadow-inner border border-transparent">
+        <div 
+          className={`absolute top-1.5 bottom-1.5 left-1.5 right-1.5 pointer-events-none`}
+        >
+          <div 
+            className={`h-full w-1/2 bg-white rounded-xl shadow-[0_1px_3px_rgba(0,0,0,0.12)] transition-transform duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] ${
+              mode === 'edit' ? 'translate-x-full' : 'translate-x-0'
+            }`}
+          />
+        </div>
+        <button 
+          type="button"
+          onClick={() => setMode('add')} 
+          className={`relative z-10 flex-1 py-2 text-sm font-bold transition-colors duration-300 ${mode === 'add' ? 'text-[var(--color-gdg-blue)]' : 'text-[#5F6368] hover:text-[#202124]'}`}>
+          Hinzufügen
+        </button>
+        <button 
+          type="button"
+          onClick={() => setMode('edit')} 
+          className={`relative z-10 flex-1 py-2 text-sm font-bold transition-colors duration-300 ${mode === 'edit' ? 'text-[var(--color-gdg-blue)]' : 'text-[#5F6368] hover:text-[#202124]'}`}>
+          Bearbeiten
+        </button>
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-6 bg-card p-6 md:p-8 rounded-xl border border-[var(--color-gdg-grey-200)] shadow-sm">
+      <div className="mb-8">
+        <h1 className="text-3xl font-extrabold mb-2">
+          {mode === 'edit' ? "Bestehenden Talk bearbeiten" : "Neuen Talk hinterlegen"}
+        </h1>
+        <p className="text-muted text-lg">
+          {mode === 'edit' ? "Wähle einen Talk aus der Liste und passe die Details an." : "Fülle das Formular aus und lade auf Wunsch eine PDF hoch, um einen neuen Vortrag anzulegen."}
+        </p>
+      </div>
+
+      {mode === 'edit' && (
+        <div className="mb-6 space-y-2 bg-card p-6 rounded-xl border border-[var(--color-gdg-grey-200)] shadow-sm">
+          <label className="text-sm font-semibold">Zu bearbeitender Talk *</label>
+          <select 
+            className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none bg-white focus:border-[var(--color-gdg-blue)]"
+            onChange={(e) => {
+              const talk = talks.find(t => `${t.year}-${t.slug}` === e.target.value);
+              setSelectedTalk(talk || null);
+            }}
+            value={selectedTalk ? `${selectedTalk.year}-${selectedTalk.slug}` : ""}
+          >
+            <option value="" disabled>-- Bitte wählen --</option>
+            {talks.map(t => (
+               <option key={`${t.year}-${t.slug}`} value={`${t.year}-${t.slug}`}>
+                 {new Date(t.date).toLocaleDateString('de-DE')} - {t.title} ({t.speaker})
+               </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {(mode === 'add' || (mode === 'edit' && selectedTalk)) && (
+      <form key={mode + (selectedTalk ? selectedTalk.slug : '')} onSubmit={handleSubmit} className="space-y-6 bg-card p-6 md:p-8 rounded-xl border border-[var(--color-gdg-grey-200)] shadow-sm">
         {error && (
           <div className="bg-red-50 text-red-600 p-4 rounded-lg text-sm mb-6 border border-red-200">
             {error}
@@ -85,30 +172,30 @@ export default function AdminPage() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="space-y-2">
             <label className="text-sm font-semibold">Titel *</label>
-            <input name="title" required className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] focus:border-[var(--color-gdg-blue)] focus:ring-1 focus:ring-[var(--color-gdg-blue)] outline-none transition-all" placeholder="z.B. Flutter Intro" />
+            <input name="title" required defaultValue={selectedTalk?.title || ""} className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] focus:border-[var(--color-gdg-blue)] focus:ring-1 focus:ring-[var(--color-gdg-blue)] outline-none transition-all" placeholder="z.B. Flutter Intro" />
           </div>
           <div className="space-y-2">
             <label className="text-sm font-semibold">Speaker *</label>
-            <input name="speaker" required className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] focus:border-[var(--color-gdg-blue)] focus:ring-1 focus:ring-[var(--color-gdg-blue)] outline-none transition-all" placeholder="z.B. Max Mustermann" />
+            <input name="speaker" required defaultValue={selectedTalk?.speaker || ""} className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] focus:border-[var(--color-gdg-blue)] focus:ring-1 focus:ring-[var(--color-gdg-blue)] outline-none transition-all" placeholder="z.B. Max Mustermann" />
           </div>
         </div>
 
         <div className="space-y-2">
           <label className="text-sm font-semibold">Kategorie *</label>
-          <input name="category" required className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none transition-all focus:border-[var(--color-gdg-blue)]" placeholder="z.B. App Entwicklung" />
+          <input name="category" required defaultValue={selectedTalk?.category || ""} className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none transition-all focus:border-[var(--color-gdg-blue)]" placeholder="z.B. App Entwicklung" />
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="space-y-2">
             <label className="text-sm font-semibold">Sprache</label>
-            <select name="language" className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none bg-white focus:border-[var(--color-gdg-blue)]">
+            <select name="language" defaultValue={selectedTalk?.language || "DE"} className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none bg-white focus:border-[var(--color-gdg-blue)]">
               <option value="DE">Deutsch (DE)</option>
               <option value="EN">Englisch (EN)</option>
             </select>
           </div>
           <div className="space-y-2">
             <label className="text-sm font-semibold">Level</label>
-            <select name="level" className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none bg-white focus:border-[var(--color-gdg-blue)]">
+            <select name="level" defaultValue={selectedTalk?.level || "Anfänger"} className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none bg-white focus:border-[var(--color-gdg-blue)]">
               <option value="Anfänger">Anfänger</option>
               <option value="Fortgeschritten">Fortgeschritten</option>
               <option value="Experte">Experte</option>
@@ -123,7 +210,7 @@ export default function AdminPage() {
           </div>
           <div className="space-y-2">
             <label className="text-sm font-semibold">Event Art</label>
-            <select name="event" className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none bg-white focus:border-[var(--color-gdg-blue)]">
+            <select name="event" defaultValue={selectedTalk?.event || "GDG Official"} className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none bg-white focus:border-[var(--color-gdg-blue)]">
               <option value="GDG Official">GDG Official</option>
               <option value="GDG Supported">GDG Supported</option>
               <option value="Extern">Extern</option>
@@ -134,18 +221,18 @@ export default function AdminPage() {
         {isFuture && (
           <div className="space-y-2">
             <label className="text-sm font-semibold">Registrierungs-Link</label>
-            <input name="eventLink" type="url" className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none transition-all focus:border-[var(--color-gdg-blue)]" placeholder="https://..." />
+            <input name="eventLink" type="url" defaultValue={selectedTalk?.eventLink || ""} className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none transition-all focus:border-[var(--color-gdg-blue)]" placeholder="https://..." />
           </div>
         )}
 
         <div className="space-y-2">
           <label className="text-sm font-semibold">Tags (kommagetrennt)</label>
-          <input name="tags" className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none transition-all focus:border-[var(--color-gdg-blue)]" placeholder="Flutter, Einführung, Dart" />
+          <input name="tags" defaultValue={(selectedTalk?.tags || []).join(", ")} className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none transition-all focus:border-[var(--color-gdg-blue)]" placeholder="Flutter, Einführung, Dart" />
         </div>
 
         <div className="space-y-2">
           <label className="text-sm font-semibold">Beschreibung</label>
-          <textarea name="description" rows={3} className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none transition-all focus:border-[var(--color-gdg-blue)]" placeholder="Kurze Beschreibung des Vortrages..."></textarea>
+          <textarea name="description" defaultValue={selectedTalk?.description || ""} rows={3} className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none transition-all focus:border-[var(--color-gdg-blue)]" placeholder="Kurze Beschreibung des Vortrages..."></textarea>
         </div>
 
         <div className="space-y-2">
@@ -176,10 +263,11 @@ export default function AdminPage() {
           {isSubmitting ? (
             <><Loader2 className="w-5 h-5 animate-spin" /><span>Speichern...</span></>
           ) : (
-            <span>Talk Hinzufügen</span>
+            <span>{mode === 'edit' ? "Änderungen Speichern" : "Talk Hinzufügen"}</span>
           )}
         </button>
       </form>
+      )}
     </div>
   );
 }

--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -10,6 +10,9 @@ export default function AdminPage() {
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState("");
   const [file, setFile] = useState<File | null>(null);
+  const [date, setDate] = useState("");
+
+  const isFuture = date ? new Date(date) > new Date() : false;
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: { "application/pdf": [".pdf"] },
@@ -42,6 +45,7 @@ export default function AdminPage() {
       setSuccess(true);
       (e.target as HTMLFormElement).reset();
       setFile(null);
+      setDate("");
     } catch (err: any) {
       setError(err.message);
     } finally {
@@ -115,7 +119,7 @@ export default function AdminPage() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="space-y-2">
             <label className="text-sm font-semibold">Datum *</label>
-            <input name="date" type="date" required className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none transition-all focus:border-[var(--color-gdg-blue)]" />
+            <input name="date" type="date" required value={date} onChange={(e) => setDate(e.target.value)} className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none transition-all focus:border-[var(--color-gdg-blue)]" />
           </div>
           <div className="space-y-2">
             <label className="text-sm font-semibold">Event Art</label>
@@ -126,6 +130,13 @@ export default function AdminPage() {
             </select>
           </div>
         </div>
+
+        {isFuture && (
+          <div className="space-y-2">
+            <label className="text-sm font-semibold">Registrierungs-Link</label>
+            <input name="eventLink" type="url" className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none transition-all focus:border-[var(--color-gdg-blue)]" placeholder="https://..." />
+          </div>
+        )}
 
         <div className="space-y-2">
           <label className="text-sm font-semibold">Tags (kommagetrennt)</label>

--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -91,15 +91,9 @@ export default function AdminPage() {
           </div>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="space-y-2">
-            <label className="text-sm font-semibold">Jahr *</label>
-            <input name="year" type="number" required defaultValue={new Date().getFullYear()} className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none transition-all focus:border-[var(--color-gdg-blue)]" />
-          </div>
-          <div className="space-y-2">
-            <label className="text-sm font-semibold">Kategorie *</label>
-            <input name="category" required className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none transition-all focus:border-[var(--color-gdg-blue)]" placeholder="z.B. App Entwicklung" />
-          </div>
+        <div className="space-y-2">
+          <label className="text-sm font-semibold">Kategorie *</label>
+          <input name="category" required className="w-full p-2.5 rounded-lg border border-[var(--color-gdg-grey-300)] outline-none transition-all focus:border-[var(--color-gdg-blue)]" placeholder="z.B. App Entwicklung" />
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 
-import { UploadCloud, CheckCircle, Loader2 } from "lucide-react";
+import { UploadCloud, CheckCircle, Loader2, FileText, Trash2 } from "lucide-react";
 import { useDropzone } from "react-dropzone";
 
 export default function AdminPage() {
@@ -11,6 +11,7 @@ export default function AdminPage() {
   const [error, setError] = useState("");
   const [file, setFile] = useState<File | null>(null);
   const [date, setDate] = useState("");
+  const [deletedPdf, setDeletedPdf] = useState(false);
 
   const [mode, setMode] = useState<'add' | 'edit'>('add');
   const [talks, setTalks] = useState<any[]>([]);
@@ -28,9 +29,11 @@ export default function AdminPage() {
   useEffect(() => {
     if (mode === 'edit' && selectedTalk) {
       setDate(selectedTalk.date || "");
+      setDeletedPdf(false);
     } else if (mode === 'add') {
       setDate("");
       setSelectedTalk(null);
+      setDeletedPdf(false);
     }
   }, [mode, selectedTalk]);
 
@@ -54,6 +57,9 @@ export default function AdminPage() {
     if (mode === 'edit' && selectedTalk) {
       formData.append("originalSlug", selectedTalk.slug);
       formData.append("originalYear", selectedTalk.year.toString());
+      if (deletedPdf) {
+        formData.append("deletePdf", "true");
+      }
     }
 
     try {
@@ -77,6 +83,7 @@ export default function AdminPage() {
       (e.target as HTMLFormElement).reset();
       setFile(null);
       setDate("");
+      setDeletedPdf(false);
     } catch (err: any) {
       setError(err.message);
     } finally {
@@ -237,22 +244,39 @@ export default function AdminPage() {
 
         <div className="space-y-2">
           <label className="text-sm font-semibold">Präsentationsfolien (PDF)</label>
-          <div
-            {...getRootProps()}
-            className={`border-2 border-dashed rounded-xl p-8 text-center cursor-pointer transition-colors ${isDragActive ? 'border-[var(--color-gdg-blue)] bg-blue-50' : 'border-[var(--color-gdg-grey-300)] hover:bg-[var(--color-gdg-grey-50)]'
-              }`}
-          >
-            <input {...getInputProps()} />
-            <UploadCloud className="w-10 h-10 mx-auto text-muted mb-4" />
-            {file ? (
-              <p className="font-medium text-[var(--color-gdg-blue)]">{file.name} (ausgewählt)</p>
-            ) : (
-              <div>
-                <p className="text-sm font-medium mb-1">PDF hierher ziehen oder klicken zum Auswählen</p>
-                <p className="text-xs text-muted">Maximal 1 Datei (.pdf)</p>
+          {mode === 'edit' && selectedTalk?.pdfFile && !deletedPdf ? (
+            <div className="border border-[var(--color-gdg-grey-300)] rounded-xl p-4 flex items-center justify-between">
+              <div className="flex items-center space-x-3">
+                <FileText className="w-8 h-8 text-[var(--color-gdg-blue)]" />
+                <span className="font-medium text-[var(--color-gdg-grey-800)]">{selectedTalk.pdfFile}</span>
               </div>
-            )}
-          </div>
+              <button 
+                type="button" 
+                onClick={() => setDeletedPdf(true)}
+                className="text-red-500 hover:bg-red-50 p-2 rounded-lg transition-colors"
+                title="PDF entfernen"
+              >
+                <Trash2 className="w-5 h-5" />
+              </button>
+            </div>
+          ) : (
+            <div
+              {...getRootProps()}
+              className={`border-2 border-dashed rounded-xl p-8 text-center cursor-pointer transition-colors ${isDragActive ? 'border-[var(--color-gdg-blue)] bg-blue-50' : 'border-[var(--color-gdg-grey-300)] hover:bg-[var(--color-gdg-grey-50)]'
+                }`}
+            >
+              <input {...getInputProps()} />
+              <UploadCloud className="w-10 h-10 mx-auto text-muted mb-4" />
+              {file ? (
+                <p className="font-medium text-[var(--color-gdg-blue)]">{file.name} (ausgewählt)</p>
+              ) : (
+                <div>
+                  <p className="text-sm font-medium mb-1">PDF hierher ziehen oder klicken zum Auswählen</p>
+                  <p className="text-xs text-muted">Maximal 1 Datei (.pdf)</p>
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         <button

--- a/apps/web/src/app/talks/[year]/[slug]/page.tsx
+++ b/apps/web/src/app/talks/[year]/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { notFound } from "next/navigation";
 export async function generateStaticParams() {
   const talks = getTalks();
   return talks.map((talk) => ({
-    year: talk.year.toString(),
+    year: new Date(talk.date).getFullYear().toString(),
     slug: talk.slug,
   }));
 }
@@ -14,7 +14,7 @@ export async function generateStaticParams() {
 export default async function TalkDetailsPage({ params }: { params: Promise<{ year: string; slug: string }> }) {
   const resolvedParams = await params;
   const talks = getTalks();
-  const talk = talks.find(t => t.year.toString() === resolvedParams.year && t.slug === resolvedParams.slug);
+  const talk = talks.find(t => new Date(t.date).getFullYear().toString() === resolvedParams.year && t.slug === resolvedParams.slug);
 
   if (!talk) {
     notFound();

--- a/apps/web/src/app/talks/[year]/[slug]/page.tsx
+++ b/apps/web/src/app/talks/[year]/[slug]/page.tsx
@@ -74,7 +74,7 @@ export default async function TalkDetailsPage({ params }: { params: Promise<{ ye
                   className="relative inline-flex w-full items-center justify-center rounded-full bg-background px-7 py-3 text-sm font-bold text-foreground group-active:scale-[0.98] transition-all"
                 >
                   <ExternalLink className="w-5 h-5 mr-3 text-[var(--color-gdg-blue)] group-hover:-translate-y-0.5 group-hover:scale-110 transition-transform duration-300" />
-                  {talk.language === "EN" ? "Registration" : "Zur Anmeldung"}
+                  Zur Anmeldung
                 </a>
               </div>
             ) : null
@@ -101,7 +101,7 @@ export default async function TalkDetailsPage({ params }: { params: Promise<{ ye
                 disabled
                 className="relative inline-flex w-full items-center justify-center rounded-full bg-background px-7 py-3 text-sm font-bold text-muted cursor-not-allowed"
               >
-                {talk.language === "EN" ? "PDF unavailable" : "PDF nicht verfügbar"}
+                PDF nicht verfügbar
               </button>
             </div>
           )}
@@ -116,9 +116,7 @@ export default async function TalkDetailsPage({ params }: { params: Promise<{ ye
 
       {isFuture ? (
         <div className="mt-12 bg-card border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] rounded-xl py-16 text-center text-muted">
-          {talk.language === "EN"
-            ? "This talk is upcoming. Presentation slides will be published here after the event."
-            : "Dieser Talk findet in der Zukunft statt. Präsentationsfolien werden nach dem Event hier veröffentlicht."}
+          Dieser Talk findet in der Zukunft statt. Präsentationsfolien werden nach dem Event hier veröffentlicht.
         </div>
       ) : talk.pdfPath ? (
         <div className="mt-12 rounded-xl overflow-hidden border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] bg-card shadow-lg flex flex-col" style={{ height: '75vh' }}>

--- a/apps/web/src/app/talks/[year]/[slug]/page.tsx
+++ b/apps/web/src/app/talks/[year]/[slug]/page.tsx
@@ -24,137 +24,137 @@ export default async function TalkDetailsPage({ params }: { params: Promise<{ ye
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-5xl">
-       <Link href="/" className="inline-flex items-center text-sm font-medium text-muted hover:text-foreground mb-8 transition-colors">
-         <ArrowLeft className="w-4 h-4 mr-2" />
-         Zurück zur Übersicht
-       </Link>
+      <Link href="/" className="inline-flex items-center text-sm font-medium text-muted hover:text-foreground mb-8 transition-colors">
+        <ArrowLeft className="w-4 h-4 mr-2" />
+        Zurück zur Übersicht
+      </Link>
 
-       <header className="mb-8">
-         <div className="flex flex-col md:flex-row md:items-start justify-between gap-6">
-           <div>
-             <div className="flex items-center gap-3 mb-3">
-                <span className="text-xs font-bold text-white bg-[var(--color-gdg-blue)] px-2.5 py-1 rounded-md uppercase tracking-wide">
-                  {talk.category}
-                </span>
-                <span className="text-xs font-medium bg-card border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] px-2.5 py-1 rounded-md text-muted">
-                  {talk.level}
-                </span>
-             </div>
-             <h1 className="text-3xl md:text-5xl font-extrabold tracking-tight mb-4">{talk.title}</h1>
-             
-             <div className="flex flex-wrap items-center gap-4 text-sm text-muted">
-                <div className="flex items-center">
-                  <User className="w-4 h-4 mr-1.5" />
-                  {talk.speaker}
-                </div>
-                <div className="flex items-center">
-                  <Calendar className="w-4 h-4 mr-1.5" />
-                  {new Date(talk.date).toLocaleDateString('de-DE', { year: 'numeric', month: 'long', day: 'numeric' })}
-                </div>
-                <div className="flex items-center">
-                  <Tag className="w-4 h-4 mr-1.5" />
-                  {talk.event}
-                </div>
-             </div>
-           </div>
-           
-           {isFuture ? (
-             talk.eventLink ? (
-               <div className="relative inline-flex shrink-0 overflow-hidden rounded-full p-[3px] shadow-sm group hover:shadow-md transition-shadow">
-                 <span 
-                   className="absolute left-1/2 top-1/2 h-[300%] w-[300%] origin-center -translate-x-1/2 -translate-y-1/2 transition-transform duration-[1000ms] ease-in-out group-hover:rotate-[180deg]"
-                   style={{
-                     background: "conic-gradient(var(--color-gdg-blue) 0deg 90deg, var(--color-gdg-red) 90deg 180deg, var(--color-gdg-yellow) 180deg 270deg, var(--color-gdg-green) 270deg 360deg)"
-                   }}
-                 />
-                 <a 
-                   href={talk.eventLink} 
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   className="relative inline-flex w-full items-center justify-center rounded-full bg-background px-7 py-3 text-sm font-bold text-foreground group-active:scale-[0.98] transition-all"
-                 >
-                 <ExternalLink className="w-5 h-5 mr-3 text-[var(--color-gdg-blue)] group-hover:-translate-y-0.5 group-hover:scale-110 transition-transform duration-300" />
-                   {talk.language === "EN" ? "Registration" : "Zur Anmeldung"}
-                 </a>
-               </div>
-             ) : null
-           ) : talk.pdfPath ? (
-             <div className="relative inline-flex shrink-0 overflow-hidden rounded-full p-[3px] shadow-sm group hover:shadow-md transition-shadow">
-               <span 
-                 className="absolute left-1/2 top-1/2 h-[300%] w-[300%] origin-center -translate-x-1/2 -translate-y-1/2 transition-transform duration-[1000ms] ease-in-out group-hover:rotate-[180deg]"
-                 style={{
-                   background: "conic-gradient(var(--color-gdg-blue) 0deg 90deg, var(--color-gdg-red) 90deg 180deg, var(--color-gdg-yellow) 180deg 270deg, var(--color-gdg-green) 270deg 360deg)"
-                 }}
-               />
-               <a 
-                 href={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}${encodeURI(talk.pdfPath)}`} 
-                 download
-                 className="relative inline-flex w-full items-center justify-center rounded-full bg-background px-7 py-3 text-sm font-bold text-foreground group-active:scale-[0.98] transition-all"
-               >
-                 <Download className="w-5 h-5 mr-3 text-[var(--color-gdg-blue)] group-hover:-translate-y-0.5 group-hover:scale-110 transition-transform duration-300" />
-                 PDF Herunterladen
-               </a>
-             </div>
-           ) : (
-             <div className="relative inline-flex shrink-0 rounded-full p-[1px] shadow-sm bg-[var(--color-gdg-grey-300)] dark:bg-[var(--color-gdg-grey-800)]">
-               <button 
-                 disabled
-                 className="relative inline-flex w-full items-center justify-center rounded-full bg-background px-7 py-3 text-sm font-bold text-muted cursor-not-allowed"
-               >
-                 {talk.language === "EN" ? "PDF unavailable" : "PDF nicht verfügbar"}
-               </button>
-             </div>
-           )}
-         </div>
-
-         {talk.description && (
-           <p className="mt-6 text-lg text-foreground/80 leading-relaxed max-w-4xl">
-             {talk.description}
-           </p>
-         )}
-       </header>
-
-       {isFuture ? (
-         <div className="mt-12 bg-card border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] rounded-xl py-16 text-center text-muted">
-           {talk.language === "EN" 
-             ? "This talk is upcoming. Presentation slides will be published here after the event."
-             : "Dieser Talk findet in der Zukunft statt. Präsentationsfolien werden nach dem Event hier veröffentlicht."}
-         </div>
-       ) : talk.pdfPath ? (
-         <div className="mt-12 rounded-xl overflow-hidden border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] bg-card shadow-lg flex flex-col" style={{ height: '75vh' }}>
-            <div className="bg-[var(--color-gdg-grey-100)] dark:bg-[var(--color-gdg-grey-900)] p-3 border-b border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] flex justify-between items-center">
-               <span className="text-sm font-medium text-muted">Präsentationsfolien</span>
+      <header className="mb-8">
+        <div className="flex flex-col md:flex-row md:items-start justify-between gap-6">
+          <div>
+            <div className="flex items-center gap-3 mb-3">
+              <span className="text-xs font-bold text-white bg-[var(--color-gdg-blue)] px-2.5 py-1 rounded-md uppercase tracking-wide">
+                {talk.category}
+              </span>
+              <span className="text-xs font-medium bg-card border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] px-2.5 py-1 rounded-md text-muted">
+                {talk.level}
+              </span>
             </div>
-            <iframe 
-              src={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}${encodeURI(talk.pdfPath)}#toolbar=1&navpanes=0&scrollbar=1`}
-              className="w-full flex-1 border-0 hidden md:block"
-              title="Präsentationsfolien Preview"
-            />
-            {process.env.NEXT_PUBLIC_GITHUB_URL ? (
-                <iframe 
-                  src={`https://docs.google.com/viewer?url=${encodeURIComponent(`${process.env.NEXT_PUBLIC_GITHUB_URL}${process.env.NEXT_PUBLIC_BASE_PATH || ''}${encodeURI(talk.pdfPath)}`)}&embedded=true`}
-                  className="w-full flex-1 border-0 block md:hidden bg-white"
-                  title="Präsentationsfolien Mobile Preview"
+            <h1 className="text-3xl md:text-5xl font-extrabold tracking-tight mb-4">{talk.title}</h1>
+
+            <div className="flex flex-wrap items-center gap-4 text-sm text-muted">
+              <div className="flex items-center">
+                <User className="w-4 h-4 mr-1.5" />
+                {talk.speaker}
+              </div>
+              <div className="flex items-center">
+                <Calendar className="w-4 h-4 mr-1.5" />
+                {new Date(talk.date).toLocaleDateString('de-DE', { year: 'numeric', month: 'long', day: 'numeric' })}
+              </div>
+              <div className="flex items-center">
+                <Tag className="w-4 h-4 mr-1.5" />
+                {talk.event}
+              </div>
+            </div>
+          </div>
+
+          {isFuture ? (
+            talk.eventLink ? (
+              <div className="relative inline-flex shrink-0 overflow-hidden rounded-full p-[3px] shadow-sm group hover:shadow-md transition-shadow">
+                <span
+                  className="absolute left-1/2 top-1/2 h-[300%] w-[300%] origin-center -translate-x-1/2 -translate-y-1/2 transition-transform duration-[1000ms] ease-in-out group-hover:rotate-[180deg]"
+                  style={{
+                    background: "conic-gradient(var(--color-gdg-blue) 0deg 90deg, var(--color-gdg-red) 90deg 180deg, var(--color-gdg-yellow) 180deg 270deg, var(--color-gdg-green) 270deg 360deg)"
+                  }}
                 />
-            ) : (
-                <div className="md:hidden flex-1 flex flex-col items-center justify-center p-8 text-center bg-[var(--color-gdg-grey-50)] dark:bg-[var(--color-gdg-grey-900)]">
-                     <p className="mb-4 text-muted text-sm">Die mobile Live-Vorschau für PDFs wird lokal nicht unterstützt (nur Online in GitHub Pages). Bitte öffne die PDF direkt:</p>
-                     <a 
-                       href={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}${encodeURI(talk.pdfPath)}`} 
-                       target="_blank" 
-                       rel="noopener noreferrer"
-                       className="text-[var(--color-gdg-blue)] underline font-medium text-sm"
-                     >
-                       PDF hier im Vollbild öffnen
-                     </a>
-                </div>
-            )}
-         </div>
-       ) : (
-         <div className="mt-12 bg-card border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] rounded-xl py-16 text-center text-muted">
-           Keine Präsentationsfolien für diesen Talk verfügbar.
-         </div>
-       )}
+                <a
+                  href={talk.eventLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="relative inline-flex w-full items-center justify-center rounded-full bg-background px-7 py-3 text-sm font-bold text-foreground group-active:scale-[0.98] transition-all"
+                >
+                  <ExternalLink className="w-5 h-5 mr-3 text-[var(--color-gdg-blue)] group-hover:-translate-y-0.5 group-hover:scale-110 transition-transform duration-300" />
+                  {talk.language === "EN" ? "Registration" : "Zur Anmeldung"}
+                </a>
+              </div>
+            ) : null
+          ) : talk.pdfPath ? (
+            <div className="relative inline-flex shrink-0 overflow-hidden rounded-full p-[3px] shadow-sm group hover:shadow-md transition-shadow">
+              <span
+                className="absolute left-1/2 top-1/2 h-[300%] w-[300%] origin-center -translate-x-1/2 -translate-y-1/2 transition-transform duration-[1000ms] ease-in-out group-hover:rotate-[180deg]"
+                style={{
+                  background: "conic-gradient(var(--color-gdg-blue) 0deg 90deg, var(--color-gdg-red) 90deg 180deg, var(--color-gdg-yellow) 180deg 270deg, var(--color-gdg-green) 270deg 360deg)"
+                }}
+              />
+              <a
+                href={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}${encodeURI(talk.pdfPath)}`}
+                download
+                className="relative inline-flex w-full items-center justify-center rounded-full bg-background px-7 py-3 text-sm font-bold text-foreground group-active:scale-[0.98] transition-all"
+              >
+                <Download className="w-5 h-5 mr-3 text-[var(--color-gdg-blue)] group-hover:-translate-y-0.5 group-hover:scale-110 transition-transform duration-300" />
+                PDF Herunterladen
+              </a>
+            </div>
+          ) : (
+            <div className="relative inline-flex shrink-0 rounded-full p-[1px] shadow-sm bg-[var(--color-gdg-grey-300)] dark:bg-[var(--color-gdg-grey-800)]">
+              <button
+                disabled
+                className="relative inline-flex w-full items-center justify-center rounded-full bg-background px-7 py-3 text-sm font-bold text-muted cursor-not-allowed"
+              >
+                {talk.language === "EN" ? "PDF unavailable" : "PDF nicht verfügbar"}
+              </button>
+            </div>
+          )}
+        </div>
+
+        {talk.description && (
+          <p className="mt-6 text-lg text-foreground/80 leading-relaxed max-w-4xl">
+            {talk.description}
+          </p>
+        )}
+      </header>
+
+      {isFuture ? (
+        <div className="mt-12 bg-card border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] rounded-xl py-16 text-center text-muted">
+          {talk.language === "EN"
+            ? "This talk is upcoming. Presentation slides will be published here after the event."
+            : "Dieser Talk findet in der Zukunft statt. Präsentationsfolien werden nach dem Event hier veröffentlicht."}
+        </div>
+      ) : talk.pdfPath ? (
+        <div className="mt-12 rounded-xl overflow-hidden border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] bg-card shadow-lg flex flex-col" style={{ height: '75vh' }}>
+          <div className="bg-[var(--color-gdg-grey-100)] dark:bg-[var(--color-gdg-grey-900)] p-3 border-b border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] flex justify-between items-center">
+            <span className="text-sm font-medium text-muted">Präsentationsfolien</span>
+          </div>
+          <iframe
+            src={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}${encodeURI(talk.pdfPath)}#toolbar=1&navpanes=0&scrollbar=1`}
+            className="w-full flex-1 border-0 hidden md:block"
+            title="Präsentationsfolien Preview"
+          />
+          {process.env.NEXT_PUBLIC_GITHUB_URL ? (
+            <iframe
+              src={`https://docs.google.com/viewer?url=${encodeURIComponent(`${process.env.NEXT_PUBLIC_GITHUB_URL}${process.env.NEXT_PUBLIC_BASE_PATH || ''}${encodeURI(talk.pdfPath)}`)}&embedded=true`}
+              className="w-full flex-1 border-0 block md:hidden bg-white"
+              title="Präsentationsfolien Mobile Preview"
+            />
+          ) : (
+            <div className="md:hidden flex-1 flex flex-col items-center justify-center p-8 text-center bg-[var(--color-gdg-grey-50)] dark:bg-[var(--color-gdg-grey-900)]">
+              <p className="mb-4 text-muted text-sm">Die mobile Live-Vorschau für PDFs wird lokal nicht unterstützt (nur Online in GitHub Pages). Bitte öffne die PDF direkt:</p>
+              <a
+                href={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}${encodeURI(talk.pdfPath)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[var(--color-gdg-blue)] underline font-medium text-sm"
+              >
+                PDF hier im Vollbild öffnen
+              </a>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="mt-12 bg-card border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] rounded-xl py-16 text-center text-muted">
+          Keine Präsentationsfolien für diesen Talk verfügbar.
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/talks/[year]/[slug]/page.tsx
+++ b/apps/web/src/app/talks/[year]/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { getTalks } from "@/lib/talks";
 import Link from "next/link";
-import { ArrowLeft, Download, Calendar, Tag, User } from "lucide-react";
+import { ArrowLeft, Download, Calendar, Tag, User, ExternalLink } from "lucide-react";
 import { notFound } from "next/navigation";
 
 export async function generateStaticParams() {
@@ -19,6 +19,8 @@ export default async function TalkDetailsPage({ params }: { params: Promise<{ ye
   if (!talk) {
     notFound();
   }
+
+  const isFuture = new Date(talk.date) > new Date();
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-5xl">
@@ -56,7 +58,27 @@ export default async function TalkDetailsPage({ params }: { params: Promise<{ ye
              </div>
            </div>
            
-           {talk.pdfPath && (
+           {isFuture ? (
+             talk.eventLink ? (
+               <div className="relative inline-flex shrink-0 overflow-hidden rounded-full p-[3px] shadow-sm group hover:shadow-md transition-shadow">
+                 <span 
+                   className="absolute left-1/2 top-1/2 h-[300%] w-[300%] origin-center -translate-x-1/2 -translate-y-1/2 transition-transform duration-[1000ms] ease-in-out group-hover:rotate-[180deg]"
+                   style={{
+                     background: "conic-gradient(var(--color-gdg-blue) 0deg 90deg, var(--color-gdg-red) 90deg 180deg, var(--color-gdg-yellow) 180deg 270deg, var(--color-gdg-green) 270deg 360deg)"
+                   }}
+                 />
+                 <a 
+                   href={talk.eventLink} 
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   className="relative inline-flex w-full items-center justify-center rounded-full bg-background px-7 py-3 text-sm font-bold text-foreground group-active:scale-[0.98] transition-all"
+                 >
+                 <ExternalLink className="w-5 h-5 mr-3 text-[var(--color-gdg-blue)] group-hover:-translate-y-0.5 group-hover:scale-110 transition-transform duration-300" />
+                   {talk.language === "EN" ? "Registration" : "Zur Anmeldung"}
+                 </a>
+               </div>
+             ) : null
+           ) : talk.pdfPath ? (
              <div className="relative inline-flex shrink-0 overflow-hidden rounded-full p-[3px] shadow-sm group hover:shadow-md transition-shadow">
                <span 
                  className="absolute left-1/2 top-1/2 h-[300%] w-[300%] origin-center -translate-x-1/2 -translate-y-1/2 transition-transform duration-[1000ms] ease-in-out group-hover:rotate-[180deg]"
@@ -73,6 +95,15 @@ export default async function TalkDetailsPage({ params }: { params: Promise<{ ye
                  PDF Herunterladen
                </a>
              </div>
+           ) : (
+             <div className="relative inline-flex shrink-0 rounded-full p-[1px] shadow-sm bg-[var(--color-gdg-grey-300)] dark:bg-[var(--color-gdg-grey-800)]">
+               <button 
+                 disabled
+                 className="relative inline-flex w-full items-center justify-center rounded-full bg-background px-7 py-3 text-sm font-bold text-muted cursor-not-allowed"
+               >
+                 {talk.language === "EN" ? "PDF unavailable" : "PDF nicht verfügbar"}
+               </button>
+             </div>
            )}
          </div>
 
@@ -83,7 +114,13 @@ export default async function TalkDetailsPage({ params }: { params: Promise<{ ye
          )}
        </header>
 
-       {talk.pdfPath ? (
+       {isFuture ? (
+         <div className="mt-12 bg-card border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] rounded-xl py-16 text-center text-muted">
+           {talk.language === "EN" 
+             ? "This talk is upcoming. Presentation slides will be published here after the event."
+             : "Dieser Talk findet in der Zukunft statt. Präsentationsfolien werden nach dem Event hier veröffentlicht."}
+         </div>
+       ) : talk.pdfPath ? (
          <div className="mt-12 rounded-xl overflow-hidden border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] bg-card shadow-lg flex flex-col" style={{ height: '75vh' }}>
             <div className="bg-[var(--color-gdg-grey-100)] dark:bg-[var(--color-gdg-grey-900)] p-3 border-b border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] flex justify-between items-center">
                <span className="text-sm font-medium text-muted">Präsentationsfolien</span>

--- a/apps/web/src/components/ClientTalkList.tsx
+++ b/apps/web/src/components/ClientTalkList.tsx
@@ -49,8 +49,9 @@ export function ClientTalkList({ talks, availableTags }: { talks: TalkWithSlug[]
   const groupedByYear = useMemo(() => {
     const groups: Record<number, TalkWithSlug[]> = {};
     for (const talk of nonPendingTalks) {
-      if (!groups[talk.year]) groups[talk.year] = [];
-      groups[talk.year].push(talk);
+      const year = new Date(talk.date).getFullYear();
+      if (!groups[year]) groups[year] = [];
+      groups[year].push(talk);
     }
     return groups;
   }, [nonPendingTalks]);
@@ -159,7 +160,7 @@ function TalkCard({ talk, isPending }: { talk: TalkWithSlug, isPending: boolean 
   return (
     <Link
       key={talk.slug}
-      href={`/talks/${talk.year}/${talk.slug}`}
+      href={`/talks/${new Date(talk.date).getFullYear()}/${talk.slug}`}
       className="block group h-full"
     >
       <div className="h-full rounded-xl border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] bg-card overflow-hidden shadow-sm hover:shadow-md transition-shadow group-hover:border-[var(--color-gdg-blue)] flex flex-col">

--- a/apps/web/src/components/ClientTalkList.tsx
+++ b/apps/web/src/components/ClientTalkList.tsx
@@ -8,6 +8,11 @@ export function ClientTalkList({ talks, availableTags }: { talks: TalkWithSlug[]
   const [search, setSearch] = useState("");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [showFiltersMobile, setShowFiltersMobile] = useState(false);
+  const [todayTimestamp, setTodayTimestamp] = useState(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return today.getTime();
+  });
 
   const toggleTag = (tag: string) => {
     setSelectedTags(prev =>
@@ -25,14 +30,30 @@ export function ClientTalkList({ talks, availableTags }: { talks: TalkWithSlug[]
     });
   }, [talks, search, selectedTags]);
 
+  const pendingTalks = useMemo(() => {
+    return filteredTalks.filter(talk => {
+      const talkDate = new Date(talk.date);
+      talkDate.setHours(0, 0, 0, 0);
+      return talkDate.getTime() > todayTimestamp;
+    });
+  }, [filteredTalks, todayTimestamp]);
+
+  const nonPendingTalks = useMemo(() => {
+    return filteredTalks.filter(talk => {
+      const talkDate = new Date(talk.date);
+      talkDate.setHours(0, 0, 0, 0);
+      return talkDate.getTime() <= todayTimestamp;
+    });
+  }, [filteredTalks, todayTimestamp]);
+
   const groupedByYear = useMemo(() => {
     const groups: Record<number, TalkWithSlug[]> = {};
-    for (const talk of filteredTalks) {
+    for (const talk of nonPendingTalks) {
       if (!groups[talk.year]) groups[talk.year] = [];
       groups[talk.year].push(talk);
     }
     return groups;
-  }, [filteredTalks]);
+  }, [nonPendingTalks]);
 
   const years = Object.keys(groupedByYear).map(Number).sort((a, b) => b - a);
 
@@ -88,52 +109,87 @@ export function ClientTalkList({ talks, availableTags }: { talks: TalkWithSlug[]
 
       {/* Main Content */}
       <main className="flex-1 space-y-12">
-        {years.length === 0 ? (
+        {pendingTalks.length === 0 && years.length === 0 ? (
           <div className="text-center py-12 text-muted">Keine Ergebnisse für deine Suche gefunden.</div>
         ) : (
-          years.map(year => (
-            <section key={year}>
-              <h2 className="text-2xl font-bold mb-6 flex items-center gap-4">
-                {year}
-                <div className="h-px bg-[var(--color-gdg-grey-200)] dark:bg-[var(--color-gdg-grey-700)] flex-1" />
-              </h2>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {groupedByYear[year].map(talk => (
-                  <Link
-                    key={talk.slug}
-                    href={`/talks/${talk.year}/${talk.slug}`}
-                    className="block group h-full"
-                  >
-                    <div className="h-full rounded-xl border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] bg-card overflow-hidden shadow-sm hover:shadow-md transition-shadow group-hover:border-[var(--color-gdg-blue)] flex flex-col">
-                      <div className="p-5 flex-1 flex flex-col">
-                        <div className="flex justify-between items-start mb-2">
-                          <span className="text-xs font-semibold text-[var(--color-gdg-blue)] uppercase tracking-wider">{talk.category}</span>
-                          <span className="text-xs text-muted">{talk.language}</span>
-                        </div>
-                        <h3 className="text-lg font-bold mb-1 leading-tight group-hover:text-[var(--color-gdg-blue)] transition-colors">{talk.title}</h3>
-                        <p className="text-sm text-muted mb-4">{talk.speaker}</p>
+          <>
+            {pendingTalks.length > 0 && (
+              <section>
+                <h2 className="text-2xl font-bold mb-6 flex items-center gap-4">
+                  Anstehende Talks
+                  <div className="h-px bg-[var(--color-gdg-grey-200)] dark:bg-[var(--color-gdg-grey-700)] flex-1" />
+                </h2>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {pendingTalks.map(talk => (
+                    <TalkCard key={talk.slug} talk={talk} isPending={true} />
+                  ))}
+                </div>
+              </section>
+            )}
 
-                        <div className="mt-auto">
-                          <div className="flex flex-wrap gap-1 mt-3">
-                            {talk.tags?.slice(0, 3).map(tag => (
-                              <span key={tag} className="text-[10px] px-2 py-0.5 rounded border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-700)] bg-background text-muted">
-                                {tag}
-                              </span>
-                            ))}
-                            {talk.tags && talk.tags.length > 3 && (
-                              <span className="text-[10px] px-2 py-0.5 rounded border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-700)] bg-background text-muted">+{talk.tags.length - 3}</span>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </Link>
-                ))}
-              </div>
-            </section>
-          ))
+            {years.length > 0 && years.map(year => (
+              <TalkSection key={year} title={year.toString()} talks={groupedByYear[year]} isPending={false} />
+            ))}
+          </>
         )}
       </main>
     </div>
   );
+}
+
+
+function TalkSection({ title, talks, isPending }: { title: string, talks: TalkWithSlug[], isPending: boolean }) {
+  return (
+    <section key={title}>
+      <h2 className="text-2xl font-bold mb-6 flex items-center gap-4">
+        {title}
+        <div className="h-px bg-[var(--color-gdg-grey-200)] dark:bg-[var(--color-gdg-grey-700)] flex-1" />
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {talks.map(talk => (
+          <TalkCard key={talk.slug} talk={talk} isPending={isPending} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+
+function TalkCard({ talk, isPending }: { talk: TalkWithSlug, isPending: boolean }) {
+  return (
+    <Link
+      key={talk.slug}
+      href={`/talks/${talk.year}/${talk.slug}`}
+      className="block group h-full"
+    >
+      <div className="h-full rounded-xl border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-800)] bg-card overflow-hidden shadow-sm hover:shadow-md transition-shadow group-hover:border-[var(--color-gdg-blue)] flex flex-col">
+        <div className="p-5 flex-1 flex flex-col">
+          <div className="flex justify-between items-start mb-2">
+            <span className="text-xs font-semibold text-[var(--color-gdg-blue)] uppercase tracking-wider">{talk.category}</span>
+            <div className="flex items-center gap-2">
+              {isPending && (
+                <span className="text-[10px] px-2 py-0.5 rounded-full font-semibold bg-amber-500 text-white uppercase tracking-wide">Anstehend</span>
+              )}
+              <span className="text-xs text-muted">{talk.language}</span>
+            </div>
+          </div>
+          <h3 className="text-lg font-bold mb-1 leading-tight group-hover:text-[var(--color-gdg-blue)] transition-colors">{talk.title}</h3>
+          <p className="text-sm text-muted mb-4">{talk.speaker}</p>
+
+          <div className="mt-auto">
+            <div className="flex flex-wrap gap-1 mt-3">
+              {talk.tags?.slice(0, 3).map(tag => (
+                <span key={tag} className="text-[10px] px-2 py-0.5 rounded border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-700)] bg-background text-muted">
+                  {tag}
+                </span>
+              ))}
+              {talk.tags && talk.tags.length > 3 && (
+                <span className="text-[10px] px-2 py-0.5 rounded border border-[var(--color-gdg-grey-200)] dark:border-[var(--color-gdg-grey-700)] bg-background text-muted">+{talk.tags.length - 3}</span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </Link>
+  )
 }

--- a/apps/web/src/lib/talks.ts
+++ b/apps/web/src/lib/talks.ts
@@ -42,7 +42,6 @@ export function getTalks(): TalkWithSlug[] {
           
           talks.push({
             ...meta,
-            year: parseInt(year, 10),
             slug: folder,
             pdfPath: pdfFile ? `/talks/${year}/${folder}/${pdfFile}` : '',
           });

--- a/apps/web/src/lib/talks.ts
+++ b/apps/web/src/lib/talks.ts
@@ -42,6 +42,7 @@ export function getTalks(): TalkWithSlug[] {
           
           talks.push({
             ...meta,
+            year: parseInt(year, 10),
             slug: folder,
             pdfPath: pdfFile ? `/talks/${year}/${folder}/${pdfFile}` : '',
           });

--- a/apps/web/tests/ui.spec.ts
+++ b/apps/web/tests/ui.spec.ts
@@ -38,17 +38,19 @@ test.describe('GDG Talk Hub UI Verification', () => {
       await expect(h1).toBeVisible();
       
       const downloadBtn = page.locator('a', { hasText: 'PDF Herunterladen' }).first();
-      await expect(downloadBtn).toBeVisible();
+      const hasPdfButton = await downloadBtn.isVisible();
       
-      const downloadHref = await downloadBtn.getAttribute('href');
-      expect(downloadHref).toBeTruthy();
-      
-      const response = await page.request.get(downloadHref!);
-      expect(response.status()).toBe(200);
-      expect(response.headers()['content-type']).toContain('pdf');
-      
-      const pdfIframe = page.locator('iframe[title="Präsentationsfolien Preview"]').first();
-      await expect(pdfIframe).toBeVisible();
+      if (hasPdfButton) {
+        const downloadHref = await downloadBtn.getAttribute('href');
+        expect(downloadHref).toBeTruthy();
+        
+        const response = await page.request.get(downloadHref!);
+        expect(response.status()).toBe(200);
+        expect(response.headers()['content-type']).toContain('pdf');
+        
+        const pdfIframe = page.locator('iframe[title="Präsentationsfolien Preview"]').first();
+        await expect(pdfIframe).toBeVisible();
+      }
     }
   });
 

--- a/packages/ui-theme/index.ts
+++ b/packages/ui-theme/index.ts
@@ -1,7 +1,6 @@
 export interface TalkMetadata {
   title: string;
   speaker: string;
-  year: number;
   category: string;
   tags: string[];
   language: string;

--- a/packages/ui-theme/index.ts
+++ b/packages/ui-theme/index.ts
@@ -8,6 +8,7 @@ export interface TalkMetadata {
   event: string;
   date: string;
   description: string;
+  eventLink?: string;
 }
 
 export const GDG_COLORS = {

--- a/talks/2026/vw_positionstechnologie/meta.json
+++ b/talks/2026/vw_positionstechnologie/meta.json
@@ -1,7 +1,6 @@
 {
     "title": "Positionstechnologie im Fahrzeug",
     "speaker": "Stefan Döring",
-    "year": 2026,
     "category": "Automotive",
     "tags": [
         "GPS",


### PR DESCRIPTION
Supersedes #2 

- [x] Removes the redundant `year` attribute from the `meta.json`
- [x] web: Adds a "pending talks" section
- [x] admin: Makes PDF slides upload optional (for adding slides later)
- [x] admin: Add page for adding PDF slides to talks without slides

I've restructured the talk list into separate functions for better modularity. Done *without* vibe coding ;)

I will create more PRs for the other features once this one is merged.

@LennartKDeveloper, what do you think about the design? I've made it a bit less colorful.

---

<img width="1309" height="714" alt="grafik" src="https://github.com/user-attachments/assets/87ed7778-a8da-43b0-8ada-8353e4ab460d" />
